### PR TITLE
`getFinalType()` checks the attacker, not the defender

### DIFF
--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -378,7 +378,7 @@ export class TypeImmunityAbAttr extends PreDefendAbAttr {
       return false;
     }
 
-    if (attacker !== pokemon && move.type === this.immuneType && move.getFinalType(pokemon) === this.immuneType) {
+    if (attacker !== pokemon && move.type === this.immuneType && move.getFinalType(attacker) === this.immuneType) {
       (args[0] as Utils.NumberHolder).value = 0;
       return true;
     }
@@ -473,7 +473,7 @@ export class NonSuperEffectiveImmunityAbAttr extends TypeImmunityAbAttr {
   }
 
   applyPreDefend(pokemon: Pokemon, passive: boolean, attacker: Pokemon, move: Move, cancelled: Utils.BooleanHolder, args: any[]): boolean {
-    if (move instanceof AttackMove && pokemon.getAttackTypeEffectiveness(move.getFinalType(pokemon), attacker) < 2) {
+    if (move instanceof AttackMove && pokemon.getAttackTypeEffectiveness(move.getFinalType(attacker), attacker) < 2) {
       cancelled.value = true;
       (args[0] as Utils.NumberHolder).value = 0;
       return true;
@@ -806,7 +806,7 @@ export class PostDefendApplyBattlerTagAbAttr extends PostDefendAbAttr {
 export class PostDefendTypeChangeAbAttr extends PostDefendAbAttr {
   applyPostDefend(pokemon: Pokemon, passive: boolean, attacker: Pokemon, move: Move, hitResult: HitResult, args: any[]): boolean {
     if (hitResult < HitResult.NO_EFFECT) {
-      const type = move.getFinalType(pokemon, true);
+      const type = move.getFinalType(attacker, true);
       const pokemonTypes = pokemon.getTypes(true);
       if (pokemonTypes.length !== 1 || pokemonTypes[0] !== type) {
         pokemon.summonData.types = [ type ];

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -1904,7 +1904,6 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
 
     applyMoveAttrs(VariableMoveTypeAttr, source, this, move);
     const types = this.getTypes(true, true);
-    move.finalType = types[0]; // TODO: is this correct?
     const cancelled = new Utils.BooleanHolder(false);
     const power = move.calculateBattlePower(source, this);
     const typeless = move.hasAttr(TypelessAttr);


### PR DESCRIPTION
This seems like it fixes it. Might look into adding tests for types or something, not sure the best way to go about it though.